### PR TITLE
Define destination in Argo for Sonarqube

### DIFF
--- a/argocd/values-dev.yaml
+++ b/argocd/values-dev.yaml
@@ -94,6 +94,8 @@ argo-cd:
             server: https://kubernetes.default.svc
           - namespace: cert-manager
             server: https://kubernetes.default.svc
+          - namespace: sonarqube
+            server: https://kubernetes.default.svc
         clusterResourceWhitelist:
           - group: '*'
             kind: '*'


### PR DESCRIPTION
Destination for Sonarqube was missing, so Argo was producing error `application destination {https://kubernetes.default.svc sonarqube} is not permitted in project 'tools'`